### PR TITLE
Use HTTPS with search engines

### DIFF
--- a/qml/js/settings/SearchEngines.js
+++ b/qml/js/settings/SearchEngines.js
@@ -1,10 +1,10 @@
 .pragma library
 
 var defaultsearchengines = [ { "name": "DuckDuckGo",
-                               "query": "http://duckduckgo.com/?q=" },
+                               "query": "https://duckduckgo.com/?q=" },
 
                              { "name": "Google",
-                               "query": "https://www.google.it/search?q=" } ];
+                               "query": "https://encrypted.google.com/search?q=" } ];
 
 function load(tx, searchengines)
 {


### PR DESCRIPTION
At first I noticed that my queries to DDG where going over HTTP in the load bar, but then changed to HTTPS (I hope that is because WebPirate supports HSTS (does it?) and after finding this file, I also notices that Google uses Google Italy and thought that I could also change it.

For more about google.com vs encrypted.google.com, please see http://security.stackexchange.com/a/32374.